### PR TITLE
Fix Supabase OAuth state handling

### DIFF
--- a/connect/auth-flow.js
+++ b/connect/auth-flow.js
@@ -160,7 +160,9 @@ export function buildAuthorizeUrl(config, { callback, state, challenge }) {
   url.searchParams.set('redirect_to', callback);
   url.searchParams.set('code_challenge', challenge);
   url.searchParams.set('code_challenge_method', 'S256');
-  url.searchParams.set('state', state);
+  // Supabase Auth owns the provider-facing OAuth state. Passing our own
+  // opaque value here makes GoTrue reject the callback as bad_oauth_state;
+  // the request-bound PKCE verifier still protects this browser flow.
   return url;
 }
 

--- a/tools/test-connect-flow.mjs
+++ b/tools/test-connect-flow.mjs
@@ -51,6 +51,7 @@ assert.equal(authorize.pathname, '/auth/v1/authorize');
 assert.equal(authorize.searchParams.get('provider'), 'discord');
 assert.equal(authorize.searchParams.get('redirect_to'), 'https://www.banodoco.ai/connect/');
 assert.equal(authorize.searchParams.get('code_challenge_method'), 'S256');
+assert.equal(authorize.searchParams.get('state'), null);
 
 const tokenExchange = exchangeCodeFetch(config, 'oauth-code', pkce.verifier);
 assert.equal(tokenExchange.url.href, `${config.supabaseOrigin}/auth/v1/token?grant_type=pkce`);

--- a/tools/test-connect-static.mjs
+++ b/tools/test-connect-static.mjs
@@ -31,6 +31,7 @@ assert.match(source, /\/auth\/v1\/token\?grant_type=pkce/);
 assert.match(source, /mode: 'cors'/);
 assert.match(source, /credentials: 'omit'/);
 assert.match(source, /code_challenge_method/);
+assert.match(flow, /Supabase Auth owns the provider-facing OAuth state/);
 assert.match(source, /code_verifier/);
 assert.match(page, /method: 'POST'/);
 assert.match(page, /approvalBody\(context\.requestToken, context\.approvalCode\)/);


### PR DESCRIPTION
## Summary
- let Supabase Auth generate and validate provider-facing OAuth state
- keep the request-bound PKCE verifier for the browser callback
- add regression coverage for the authorize URL

## Verification
- `node tools/test-connect-flow.mjs`
- `node tools/test-connect-static.mjs`
- `npm run test:static`